### PR TITLE
111bugfixes

### DIFF
--- a/app/src/main/java/com/pokemonshowdown/app/BattleFragment.java
+++ b/app/src/main/java/com/pokemonshowdown/app/BattleFragment.java
@@ -1378,6 +1378,10 @@ public class BattleFragment extends Fragment {
             ArrayList<Integer> lineUp = new ArrayList<>();
             for (int i = 0; i < mPlayer1Team.size(); i++) {
                 lineUp.add(i + 1); // 1 2 3 4 5 6
+
+                // here we reset the active flags for all the pokemons
+                // this is necessary for vgc as the pokemon 1 and 2 are active and if they are not selected they stay active until the end of the game since the next request item doenst have them in
+                mPlayer1Team.get(i).setActive(false);
             }
 
             // starting with user selection

--- a/app/src/main/res/layout/fragment_battle_teampreview.xml
+++ b/app/src/main/res/layout/fragment_battle_teampreview.xml
@@ -52,7 +52,7 @@
         android:contentDescription="@string/pokemon_icon"/>
 
     <ImageView
-        android:id="@+id/p2f_prev"
+        android:id="@+id/p2a_prev"
         style="@style/fragment_battle_teampreview_pokemon"
         android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"
@@ -61,7 +61,7 @@
         android:contentDescription="@string/pokemon_icon"/>
 
     <ImageView
-        android:id="@+id/p2e_prev"
+        android:id="@+id/p2b_prev"
         style="@style/fragment_battle_teampreview_pokemon"
         android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"
@@ -70,7 +70,7 @@
         android:contentDescription="@string/pokemon_icon"/>
 
     <ImageView
-        android:id="@+id/p2d_prev"
+        android:id="@+id/p2c_prev"
         style="@style/fragment_battle_teampreview_pokemon"
         android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"
@@ -79,7 +79,7 @@
         android:contentDescription="@string/pokemon_icon"/>
 
     <ImageView
-        android:id="@+id/p2c_prev"
+        android:id="@+id/p2d_prev"
         style="@style/fragment_battle_teampreview_pokemon"
         android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"
@@ -88,7 +88,7 @@
         android:contentDescription="@string/pokemon_icon"/>
 
     <ImageView
-        android:id="@+id/p2b_prev"
+        android:id="@+id/p2e_prev"
         style="@style/fragment_battle_teampreview_pokemon"
         android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"
@@ -97,7 +97,7 @@
         android:contentDescription="@string/pokemon_icon"/>
 
     <ImageView
-        android:id="@+id/p2a_prev"
+        android:id="@+id/p2f_prev"
         style="@style/fragment_battle_teampreview_pokemon"
         android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"


### PR DESCRIPTION
- First commit fixes pokemon icon position in triples
before :
ABC
DEF
D had targets CB and F, so the UI was wrong.
Now the p2 icons are reversed (only drawback is that the enemy teampreview are in reverse order, but it doesnt really matter)

- Second commit fixes VGC JSONException:
     when the 2 first pokemons are not selected, they stay as state = active because they disseapear in the next request item sent from the server


